### PR TITLE
[#19] Validate language from path

### DIFF
--- a/src/plugin/onCreatePage.ts
+++ b/src/plugin/onCreatePage.ts
@@ -87,7 +87,7 @@ export const onCreatePage = async (
   if (pageOptions?.getLanguageFromPath) {
     const result = match<{lang: string}>(pageOptions.matchPath)(page.path);
     if (!result) return;
-    const language = result.params.lang || defaultLanguage;
+    const language = languages.find((lng) => lng === result.params.lang) || defaultLanguage;
     const originalPath = page.path.replace(`/${language}`, '');
     const routed = Boolean(result.params.lang);
     newPage = await generatePage({language, originalPath, routed, pageOptions});


### PR DESCRIPTION
Use defaultLanguage also if language extracted from path is not in pluginOptions.languages (see #19).