### PR TITLE
Support in case URL contains an anchor hashtag

### DIFF
--- a/src/plugin/wrapPageElement.tsx
+++ b/src/plugin/wrapPageElement.tsx
@@ -54,7 +54,7 @@ export const wrapPageElement = (
 
       if (detected !== defaultLanguage) {
         const queryParams = search || '';
-        const newUrl = withPrefix(`/${detected}${location.pathname}${queryParams}`);
+        const newUrl = withPrefix(`/${detected}${location.pathname}${queryParams}${location.hash}`);
         window.location.replace(newUrl);
         return null;
       }


### PR DESCRIPTION
In case an URL contains an anchor hashtag, currently, this plugin isn't supporting.