### PR TITLE
Add clarification on siteUrl setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ plugins: [
       path: `${__dirname}/locales`,
       languages: [`en`, `es`, `de`],
       defaultLanguage: `en`,
-
+      // if you are using Helmet, you must include siteUrl, and make sure you add http:https
+      siteUrl: `https://example.com/`,
       // you can pass any i18next options
       // pass following options to allow message content as a key
       i18nextOptions: {


### PR DESCRIPTION
I had this issue, and by just putting the site without http/https, the canonical and hreflang were duplicated