### PR TITLE
Fix: redirect target url with path-prefix

### DIFF
--- a/src/plugin/wrapPageElement.tsx
+++ b/src/plugin/wrapPageElement.tsx
@@ -16,6 +16,15 @@ const withI18next = (i18n: I18n, context: I18NextContext) => (children: any) => 
   );
 };
 
+const removePathPrefix = (pathname: string) => {
+  const pathPrefix = withPrefix('/');
+  if (pathname.startsWith(pathPrefix)) {
+    return pathname.replace(pathPrefix, '/');
+  }
+
+  return pathname;
+};
+
 export const wrapPageElement = (
   {element, props}: WrapPageElementBrowserArgs<any, PageContext>,
   {
@@ -51,7 +60,9 @@ export const wrapPageElement = (
 
       if (detected !== defaultLanguage) {
         const queryParams = search || '';
-        const newUrl = withPrefix(`/${detected}${location.pathname}${queryParams}${location.hash}`);
+        const newUrl = withPrefix(
+          `/${detected}${removePathPrefix(location.pathname)}${queryParams}${location.hash}`
+        );
         window.location.replace(newUrl);
         return null;
       }


### PR DESCRIPTION
## Problem

Fix: #50 

> gastby-plugin-react-i18next redirect to user's prefered language router with plugin configuration { redirect: true }.
This redirect does not work with gatsby.js' s pathPrefix option.
eg) when user with prefered language configuration, { en: 0.9, ja: 0.8 }, accesses example.github.io/hoge/bar/ja/.
Expected behavior is that site will be redirected to example.github.io/hoge/bar/en/.
Actual behavior is that site will be redirected to example.github.io/hoge/bar/ja/hoge/bar/


## Solution

remove path-prefix from `location.pathname`