### PR TITLE
add client-ony routes matchPaths to language pages

### DIFF
--- a/src/plugin/onCreatePage.ts
+++ b/src/plugin/onCreatePage.ts
@@ -101,6 +101,9 @@ export const onCreatePage = async (
     if (regexp.test(localePage.path)) {
       localePage.matchPath = `/${lng}/*`;
     }
+    if (localePage.matchPath !== undefined) {
+      localePage.matchPath = `/${lng}${localePage.matchPath}`;
+    }
     createPage(localePage);
   });
 };


### PR DESCRIPTION
I thought I'd go ahead a make this PR that adds support for Gatsby's Client-Only routes like `[...].js`.

I think this is all that's needed and works for my case, feel free to discuss/modify.