### PR TITLE
fix: add language prefix for dynamic routes

### DIFF
--- a/src/plugin/onCreatePage.ts
+++ b/src/plugin/onCreatePage.ts
@@ -32,10 +32,12 @@ export const onCreatePage = async (
     path = page.path,
     originalPath = page.path,
     routed = false,
+    matchPath = page.matchPath,
     pageOptions
   }: GeneratePageParams): Promise<Page<PageContext>> => {
     return {
       ...page,
+      matchPath,
       path,
       context: {
         ...page.context,
@@ -95,6 +97,7 @@ export const onCreatePage = async (
     const localePage = await generatePage({
       language: lng,
       path: `${lng}${page.path}`,
+      matchPath: page.matchPath ? `/${lng}${page.matchPath}` : undefined,
       routed: true
     });
     const regexp = new RegExp('/404/?$');


### PR DESCRIPTION
This PR should fix the #57 issue.

Gatsby uses `page.matchPath` for client-side routes and this plugin never changes that to add language prefix.

Reference: https://www.gatsbyjs.com/docs/gatsby-internals-terminology/#matchpath