### PR TITLE
wrapPageElement: Prevent rerendering every time useTranslation() is used

### DIFF
--- a/src/plugin/wrapPageElement.tsx
+++ b/src/plugin/wrapPageElement.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import {withPrefix, WrapPageElementBrowserArgs} from 'gatsby';
 // @ts-ignore
 import browserLang from 'browser-lang';
-import {I18NextContext, LANGUAGE_KEY, PageContext, PluginOptions, LocaleNode} from '../types';
+import {
+  I18NextContext,
+  LANGUAGE_KEY,
+  PageContext,
+  PluginOptions,
+  LocaleNode,
+  Resource,
+  ResourceLanguage,
+  ResourceKey
+} from '../types';
 import i18next, {i18n as I18n} from 'i18next';
 import {I18nextProvider} from 'react-i18next';
 import {I18nextContext} from '../i18nextContext';
@@ -103,10 +112,21 @@ export const wrapPageElement = (
   defaultNS = namespaces.find((ns) => ns !== defaultNS) || defaultNS;
   const fallbackNS = namespaces.filter((ns) => ns !== defaultNS);
 
+  const resources: Resource = localeNodes.reduce<Resource>((res: Resource, {node}) => {
+    const parsedData: ResourceKey = JSON.parse(node.data);
+
+    if (!(node.language in res)) res[node.language] = {};
+
+    res[node.language][node.ns] = parsedData;
+
+    return res;
+  }, {});
+
   const i18n = i18next.createInstance();
 
   i18n.init({
     ...i18nextOptions,
+    resources,
     lng: language,
     fallbackLng: defaultLanguage,
     defaultNS,
@@ -114,11 +134,6 @@ export const wrapPageElement = (
     react: {
       useSuspense: false
     }
-  });
-
-  localeNodes.forEach(({node}) => {
-    const parsedData = JSON.parse(node.data);
-    i18n.addResourceBundle(node.language, node.ns, parsedData);
   });
 
   if (i18n.language !== language) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ import {NodeInput} from 'gatsby';
 
 export const LANGUAGE_KEY = 'gatsby-i18next-language';
 
+export type {Resource, ResourceLanguage, ResourceKey} from 'i18next';
+
 export type PageOptions = {
   matchPath: string;
   getLanguageFromPath?: boolean;


### PR DESCRIPTION
Instead of relying on i18n.addResourceBundle(). Compose the translation
resources, and pass it into i18n.init(). This lets i18n initialize
immediately and synchronously. Otherwise, i18n would initialize
asynchronously, which would trigger a rerender.

Fix #63