### PR TITLE
Use Gatsby window.__replace for redirect

### DIFF
--- a/src/plugin/wrapPageElement.tsx
+++ b/src/plugin/wrapPageElement.tsx
@@ -72,7 +72,7 @@ export const wrapPageElement = (
         const newUrl = withPrefix(
           `/${detected}${removePathPrefix(location.pathname)}${queryParams}${location.hash}`
         );
-        window.location.replace(newUrl);
+        window.___replace(newUrl);
         return null;
       }
     }


### PR DESCRIPTION
`window.location.replace` will cause the a full page reload, which is not desired. Also we discovered an issue with Safari that it might break chunk loading:

![image](https://user-images.githubusercontent.com/648142/139227809-1ddc0512-c6e3-4951-ab0e-25d789e7624c.png)

Unfortunately it leads to a redirection loop because Gatsby will reload the page when the chunk is missing. See https://github.com/gatsbyjs/gatsby/commit/fc83cb79ed13514859154a4bb1499b2e25853a2a

The way to avoid this issue, is to use Gatsby's navigation hooks.

https://www.gatsbyjs.com/docs/production-app/#___push-___replace-and-___navigate

The redirect loop goes away after we implemented the fix.