### PR TITLE
Fix gatsby-plugin-sitemap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ plugins: [
   {
     resolve: 'gatsby-plugin-sitemap',
     options: {
-      exclude: ['/**/404', '/**/404.html'],
+      excludes: ['/**/404', '/**/404.html'],
       query: `
           {
             site {


### PR DESCRIPTION
`As of v4 the 'exclude' option was renamed to 'excludes'`, see https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/?=sitemap#options