### PR TITLE
Accepts data objects from gatsby queries

### DIFF
--- a/src/plugin/wrapPageElement.tsx
+++ b/src/plugin/wrapPageElement.tsx
@@ -114,11 +114,11 @@ export const wrapPageElement = (
   const fallbackNS = namespaces.filter((ns) => ns !== defaultNS);
 
   const resources: Resource = localeNodes.reduce<Resource>((res: Resource, {node}) => {
-    const parsedData: ResourceKey = JSON.parse(node.data);
+    const parsedData: ResourceKey = typeof node.data === 'object' ? node.data : JSON.parse(node.data);
 
     if (!(node.language in res)) res[node.language] = {};
 
-    res[node.language][node.ns] = parsedData;
+    res[node.language][node.ns || defaultNS] = parsedData;
 
     return res;
   }, {});


### PR DESCRIPTION
Two simple things:

- Now it accepts objects as a result of the `data` field of the query
- Fallbacks to `defaultNS` if the query doesnt contain `ns`