### PR TITLE
feat: update 404 matchPage on alternative languages only

### DIFF
--- a/src/plugin/onCreatePage.ts
+++ b/src/plugin/onCreatePage.ts
@@ -102,7 +102,7 @@ export const onCreatePage = async (
       routed: true
     });
     const regexp = new RegExp('/404/?$');
-    if (regexp.test(localePage.path)) {
+    if (regexp.test(localePage.path && lng !== defaultLanguage) {
       localePage.matchPath = `/${lng}/*`;
     }
     if (localePage.matchPath !== undefined) {


### PR DESCRIPTION
Avoids updating the default locales match page.

This will leave the default language as the base 404 page.