### PR TITLE
Fix suggested GraphQL query in an error message

### DIFF
--- a/src/plugin/wrapPageElement.tsx
+++ b/src/plugin/wrapPageElement.tsx
@@ -99,7 +99,7 @@ export const wrapPageElement = (
       
       export const query = graphql\`
         query($language: String!) {
-          ${localeJsonNodeName}: allLocale(language: {eq: $language}) {
+          ${localeJsonNodeName}: allLocale(filter: {language: {eq: $language}}) {
             edges {
               node {
                 ns


### PR DESCRIPTION
The GraphQL query suggested in "No translations were found" error message is incorrect and produces an error.

```
Unknown argument "language" on field "Query.allLocale".
```

The current README includes the correct query; hence, I updated the one in the error message.

related to #176